### PR TITLE
Only show room bookings from today

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -45,7 +45,8 @@ def fetch_events(calendar_id)
                                  max_results: 5,
                                  single_events: true,
                                  order_by: 'startTime',
-                                 time_min: Time.now.iso8601)
+                                 time_min: Time.now.iso8601,
+                                 time_max: Date.today.+(1).to_time.iso8601)
 
   response.items
 end


### PR DESCRIPTION
The purpose of the dashboard is to see which of the meeting rooms are free right now or for the next few hours. Given that aim, seeing events from future days just clutters the display.

<img width="1365" alt="screen shot 2018-08-17 at 10 51 37" src="https://user-images.githubusercontent.com/74812/44260171-8d136a80-a20b-11e8-94e8-68fb989af893.png">
