### PR TITLE
Show format for .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 ## Getting Started
 
- - Request a CLIENT_ID and CLIENT_SECRET from developers.google.com, making sure
+ - Request a client ID and client secret from developers.google.com, making sure
      it has access to the Google Calendar API save these into `.env`
+
+     ```
+     GOOGLE_CLIENT_ID=…
+     GOOGLE_CLIENT_SECRET=…
+     ```
  - On the first run, the app needs to get permission to fetch the calendars as a
      user. The console will display a URL that you need to visit in your
      browser, after you authorise the request, you'll be given a token. Copy and


### PR DESCRIPTION
The README described the variables as CLIENT_ID and CLIENT_SECRET, but the code looks for environment variables prefixed with GOOGLE_. Add the format of `.env` to the README to make it clearer.