### PR TITLE
Remove today's date from individual entries

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -56,7 +56,7 @@ get '/' do
   @the_hide_events = fetch_events('dxw.com_3936393930353336393539@resource.calendar.google.com')
   @ground_floor_events = fetch_events('dxw.com_2d36303034323634352d353334@resource.calendar.google.com')
   @wellbeing_room_events = fetch_events('dxw.com_3437393236383531353437@resource.calendar.google.com')
+  @today = Date.today.to_time.iso8601
 
   haml :index
 end
-

--- a/views/index.haml
+++ b/views/index.haml
@@ -4,6 +4,8 @@
 
   %body
     .calendar
+      %h1.light-blue
+        = "#{@today.strftime('%B %e %Y')}"
       .room
         %h2.light-blue Main Meeting Room
         - if @ground_floor_events
@@ -12,7 +14,7 @@
               %li
                 .title.bg-light-blue
                   = event.summary || 'Unspecified'
-                .datetime= "#{event.start.date || event.start.date_time.strftime("%b %e, %l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
+                .datetime= "#{event.start.date || event.start.date_time.strftime("%l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
                 %em.organiser
                   - if event.organizer
                     = "#{event.organizer.display_name || event.organizer.email}"
@@ -27,7 +29,7 @@
               %li
                 .title.bg-dark-blue
                   = event.summary || 'Unspecified'
-                .datetime= "#{event.start.date || event.start.date_time.strftime("%b %e, %l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
+                .datetime= "#{event.start.date || event.start.date_time.strftime("%l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
                 %em.organiser
                   - if event.organizer
                     = "#{event.organizer.display_name || event.organizer.email}"
@@ -42,7 +44,7 @@
               %li
                 .title.bg-turquoise
                   = event.summary || 'Unspecified'
-                .datetime= "#{event.start.date || event.start.date_time.strftime("%b %e, %l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
+                .datetime= "#{event.start.date || event.start.date_time.strftime("%l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
                 %em.organiser
                   - if event.organizer
                     = "#{event.organizer.display_name || event.organizer.email}"


### PR DESCRIPTION
We assume we're looking at room bookings for today only, so remove the redundant date from each entry, and instead add today's date to the top of the page. Seeing today's date at the top of the pagre helps the user know the calendar display is up to date and not stale.

See screenshot for updated UI

<img width="1249" alt="screen shot 2018-08-17 at 11 13 14" src="https://user-images.githubusercontent.com/1089521/44261208-e0d38300-a20e-11e8-86f6-7e6c8cf58fcb.png">
