### PR TITLE
Refresh the dashboard every 5 minutes

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -1,6 +1,7 @@
 %html
   %head
     %link{:rel => 'stylesheet', :type => 'text/css', :href => '/stylesheets/styles.css'}
+    %meta{'http-equiv' => 'refresh', :content => '300'}
 
   %body
     .calendar


### PR DESCRIPTION
We want the dashboard to be an up to date view of the room bookings.
Using a low-fi meta tag to refresh the page every 5 minutes is a decent
enough solution for now. If we have trouble with intermittent network
connections or API availability we could use a more complex approach
where we don't lose the old data on refresh.