### PR TITLE
(chore) Remove redundant port number from docker start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY . $INSTALL_PATH
 
 EXPOSE 9292
 
-CMD ["rackup", "--host", "0.0.0.0", "-p", "9292"]
+CMD ["rackup", "--host", "0.0.0.0"]


### PR DESCRIPTION
It will use the defaultof 9292 anyway