### PR TITLE
(Chore) Add `/check` route

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -60,3 +60,7 @@ get '/' do
 
   haml :index
 end
+
+get '/check' do
+  'Im alive!'
+end


### PR DESCRIPTION
* The load balancers need a path to send health check requests to, but
the root path takes too long to respond. The `/check` route simply
responds 'Im alive!'