### PR TITLE
Exclude declined events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
      GOOGLE_CLIENT_ID=…
      GOOGLE_CLIENT_SECRET=…
      ```
+
+    If you change your credentials you'll need to remove the `token.yaml` file
+    to get the app to reauthorise
  - On the first run, the app needs to get permission to fetch the calendars as a
      user. The console will display a URL that you need to visit in your
      browser, after you authorise the request, you'll be given a token. Copy and

--- a/app.rb
+++ b/app.rb
@@ -57,7 +57,10 @@ def fetch_events(calendar_id)
                                  time_min: Time.now.iso8601,
                                  time_max: Date.today.+(1).to_time.iso8601)
 
-  response.items
+  # filter out any declined events – they normally represent a clash or room release
+  response.items.reject { |event|
+    event.attendees.find(&:self).response_status == 'declined'
+  }
 end
 
 get '/' do

--- a/app.rb
+++ b/app.rb
@@ -48,7 +48,7 @@ def service
 end
 
 
-# Fetch the next 2 events for this room
+# Fetch the next 5 events today for this room
 def fetch_events(calendar_id)
   response = service.list_events(calendar_id,
                                  max_results: 5,


### PR DESCRIPTION
Previously those events were shown in the same way as accepted events,
giving the impression of clashes and of reservations where there are
none.

An alternative solution would be to present declined events differently,
but I cannot see the value that seeing those declined events brings,
given the use of the dashboard.

This PR also includes two minor tweaks to documentation, as separate commits, found in the process of making the functional change.