### PR TITLE
Handle events with no attendees

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -59,6 +59,7 @@ def fetch_events(calendar_id)
 
   # filter out any declined events – they normally represent a clash or room release
   response.items.reject { |event|
+    next if event.attendees.nil?
     event.attendees.find(&:self).response_status == 'declined'
   }
 end


### PR DESCRIPTION
Added a guard clause to prevent nils causing errors.

There was a private event in one of the rooms that had no attendees (returned by the calendar API as `nil` rather than an empty array). This caused `.find(&:self)` to be called on nil which caused the app to blow up.