### PR TITLE
Improve displayed summary of private events

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -15,12 +15,12 @@
               %li
                 .datetime= "#{event.start.date || event.start.date_time.strftime("%l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
                 .title
-                  = event.summary || 'Unspecified'
+                  = event.summary || 'Private or unspecified'
                 %em.organiser
                   - if event.organizer
                     = "#{event.organizer.display_name || event.organizer.email}"
                   - else
-                    No organiser specified
+                    Private or unspecified
       .room.room__2
         %h2.dark-blue
           The Hide
@@ -30,12 +30,12 @@
               %li
                 .datetime= "#{event.start.date || event.start.date_time.strftime("%l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
                 .title
-                  = event.summary || 'Unspecified'
+                  = event.summary || 'Private or unspecified'
                 %em.organiser
                   - if event.organizer
                     = "#{event.organizer.display_name || event.organizer.email}"
                   - else
-                    No organiser specified
+                    Private or unspecified
 
       .room.room__3
         %h2.turquoise Wellbeing Room
@@ -45,9 +45,9 @@
               %li
                 .datetime= "#{event.start.date || event.start.date_time.strftime("%l:%M %P")} – #{event.end.date || event.end.date_time.strftime("%l:%M %P")}"
                 .title
-                  = event.summary || 'Unspecified'
+                  = event.summary || 'Private or unspecified'
                 %em.organiser
                   - if event.organizer
                     = "#{event.organizer.display_name || event.organizer.email}"
                   - else
-                    No organiser specified
+                    Private or unspecified


### PR DESCRIPTION
Private events have a nil `summary`.

Previously, the app was showing `’Unspecified’` when it encountered a nil summary.

This text confused some colleagues, who thought it meant the room was unused. This created awkwardness and upset for both the person who had booked the room and the person “squatting” in the room.

This commit changes the fallback text to `’Private or unspecified’` for nil `summary` and `organizer` fields.

Hopefully this will make it less confusing when a private event is displayed.