### PR TITLE
Add support for physical free/busy indicators

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -185,6 +185,14 @@ get '/board/:slug' do
   haml :multi_room
 end
 
+get '/room/:slug' do
+
+  @room = ROOMS[params['slug'].to_sym]
+  @today = Date.today
+
+  haml :room
+end
+
 get '/check' do
   'Im alive!'
 end

--- a/views/room.haml
+++ b/views/room.haml
@@ -1,0 +1,25 @@
+%html
+  %head
+    %title #{@room.name} - Room Dashboards - dxw
+    %link{:rel => 'stylesheet', :type => 'text/css', :href => '/stylesheets/styles.css'}
+    %meta{'http-equiv' => 'refresh', :content => '300'}
+
+  %body.kindle
+    %h1
+      %span= @room.name
+    .calendar
+      .room{:class => @room.css_class}
+        %ul
+          - if @room.empty
+            %li.event.empty
+              .datetime Until<br>#{@room.empty_until_string}
+              .title Empty
+          - @room.events.each do |event|
+            %li.event{:class => ("now" if event[:now])}
+              .datetime
+                - if event[:now]
+                  Until<br>#{event[:end_time_string]}
+                - else
+                  #{event[:start_time_string]} – #{event[:end_time_string]}
+              .title= event[:summary]
+              %em.organiser= event[:organiser]


### PR DESCRIPTION
This adds support for the free/busy indicators in the Leeds office.

![4A489091-746C-4203-BF73-CB3F938B989A_1_105_c](https://user-images.githubusercontent.com/619082/73079769-a3236100-3ebc-11ea-936c-a4a60fb7762c.jpeg)

It:

* Adds some logic for determining if a room has an event upcoming (other than the current one).
* Adds some maths for how long before the current event ends and the next event begins.
* Lets rooms have an RGB colour to be displayed on the physical device.
* Includes a flag for physical free/busy indicators to turn off between 7pm and 8am.
* Exposes all of the above via JSON.
* Adds a one-room view (handy for displaying on small screens) as a convenient side effect.

The code which drives the devices themselves lives [in this repository](https://github.com/dxw/physical-free-busy-devices).