### PR TITLE
Events will now show time remaining if less than an hour

### DIFF
--- a/views/multi_room.haml
+++ b/views/multi_room.haml
@@ -16,13 +16,18 @@
           %ul
             - if room.empty
               %li.event.empty
-                .datetime Until<br>#{room.empty_until_string}
+                .datetime
+                  Until<br>#{room.empty_until_string}
+                  - if room.minutes_to_next_event and room.minutes_to_next_event < 60
+                    <br>(#{room.minutes_to_next_event} mins)
                 .title Empty
             - room.events.each do |event|
               %li.event{:class => ("now" if event[:now])}
                 .datetime
                   - if event[:now]
                     Until<br>#{event[:end_time_string]}
+                    - if room.minutes_to_end_of_event and room.minutes_to_end_of_event < 60
+                      <br>(#{room.minutes_to_end_of_event} mins)
                   - else
                     #{event[:start_time_string]} – #{event[:end_time_string]}
                 .title= event[:summary]

--- a/views/room.haml
+++ b/views/room.haml
@@ -12,13 +12,18 @@
         %ul
           - if @room.empty
             %li.event.empty
-              .datetime Until<br>#{@room.empty_until_string}
+              .datetime
+                Until<br>#{@room.empty_until_string}
+                - if @room.minutes_to_next_event and @room.minutes_to_next_event < 60
+                  <br>(#{@room.minutes_to_next_event} mins)
               .title Empty
           - @room.events.each do |event|
             %li.event{:class => ("now" if event[:now])}
               .datetime
                 - if event[:now]
                   Until<br>#{event[:end_time_string]}
+                  - if @room.minutes_to_end_of_event and @room.minutes_to_end_of_event < 60
+                    <br>(#{@room.minutes_to_end_of_event} mins)
                 - else
                   #{event[:start_time_string]} – #{event[:end_time_string]}
               .title= event[:summary]


### PR DESCRIPTION
Where a room is either empty for less than an hour or where the current event ends in less than an hour, show the number of minutes remaining.

![localhost_9292_board_leeds](https://user-images.githubusercontent.com/619082/80953260-11988900-8df3-11ea-82a9-ba71bd743d7c.png)
