### PR TITLE
(9) Add automated tests for the dashboard

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,8 @@ gem "sinatra"
 gem "terrafile"
 gem "rack", ">= 2.0.6" # CVE-2018-16471, CVE-2018-16470
 gem "json"
-
+gem "rspec"
+gem "rack-test"
 gem "standard"
+gem "webmock"
+gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,21 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    capybara (3.33.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
+    diff-lcs (1.4.4)
     dotenv (2.5.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
@@ -35,6 +46,7 @@ GEM
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
+    hashdiff (1.0.1)
     httpclient (2.8.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -53,10 +65,14 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
     minitest (5.14.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.2)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     os (0.9.6)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -68,10 +84,13 @@ GEM
     rack (2.1.4)
     rack-protection (2.0.3)
       rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    regexp_parser (1.7.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -80,6 +99,19 @@ GEM
       listen (~> 3.0)
     retriable (3.1.2)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
     rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -91,6 +123,7 @@ GEM
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -117,23 +150,33 @@ GEM
       thread_safe (~> 0.1)
     uber (0.1.0)
     unicode-display_width (1.6.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport
+  capybara
   dotenv
   google-api-client (~> 0.8)
   haml
   json
   pry
   rack (>= 2.0.6)
+  rack-test
   rerun
+  rspec
   sass
   sinatra
   standard
   terrafile
+  webmock
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/lib/room.rb
+++ b/lib/room.rb
@@ -78,7 +78,7 @@ class Room
     # filter out any declined events – they normally represent a clash or room release
     response.items.reject { |event|
       next if event.attendees.nil?
-      event.attendees.find(&:self).response_status == "declined"
+      event.attendees.all? { |attendee| attendee.response_status == "declined" }
     }
   end
 end

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 OOB_URI = "urn:ietf:wg:oauth:2.0:oob"
-TOKEN_PATH = "token.yaml"
+TOKEN_PATH = if ENV["RACK_ENV"] == "test"
+  "spec/test_token.yaml"
+else
+  "token.yaml"
+end
 SCOPE = Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY
 
 def authorize

--- a/script/test
+++ b/script/test
@@ -23,3 +23,6 @@ node_modules/.bin/ajv -s tests/schema/rooms.schema.json -d rooms.json
 
 echo "==> Validating boards JSON…"
 node_modules/.bin/ajv -s tests/schema/boards.schema.json -d boards.json
+
+echo "==> Running tests..."
+bundle exec rspec

--- a/spec/app_api_spec.rb
+++ b/spec/app_api_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe "app API" do
+  context "when hitting a single room API point" do
+    before do # Overriding this constant so the response won't stay cached between examples
+      stub_const("CACHE_EXPIRY_TIMEOUT", 0)
+    end
+
+    it "returns a valid response when there are no events" do
+      stub_gcal_request(gcal_fake_response([]))
+      response = get "/room/zoom_test01.json"
+
+      expect(JSON.parse(response.body)["empty"]).to be true
+      expect(JSON.parse(response.body)["events"]).to be_empty
+    end
+
+    it "returns a valid response including the events when there are any" do
+      stub_gcal_request(gcal_fake_response(gcal_fake_events_with_attendees))
+      response = get "/room/zoom_test01.json"
+
+      expect(JSON.parse(response.body)["events"].count).to eq 2
+    end
+
+    it "returns a valid response not including events without attendees or when all attendees have declined" do
+      stub_gcal_request(gcal_fake_response(gcal_fake_events_without_attendees))
+      response = get "/room/zoom_test01.json"
+
+      expect(JSON.parse(response.body)["events"]).to be_empty
+    end
+  end
+end

--- a/spec/app_board_view_spec.rb
+++ b/spec/app_board_view_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+RSpec.describe "Board view", type: :feature do
+  before do
+    Capybara.app = Sinatra::Application
+    stub_const("CACHE_EXPIRY_TIMEOUT", 0)
+  end
+
+  context "get '/board/dxw'" do
+    it "shows today's date" do
+      stub_gcal_request(gcal_fake_response([]))
+      visit "/board/dxw"
+
+      expect(page).to have_selector("#datetime_date", text: Date.today.strftime("%A, %B %e"))
+    end
+    it "shows all the Zoom Meeting Rooms" do
+      stub_gcal_request(gcal_fake_response([]))
+      visit "/board/dxw"
+
+      expect(page).to have_content("Zoom Test01 Meeting Room")
+      expect(page).to have_content("Zoom Test02 Meeting Room")
+      expect(page).to have_content("Zoom Test03 Meeting Room")
+      expect(page).not_to have_content("Hoxton Test01 Meeting Room")
+      expect(page).not_to have_content("Leeds Test01 Meeting Room")
+    end
+  end
+
+  context "get '/board/hoxton" do
+    it "shows the three meeting rooms" do
+      stub_gcal_request(gcal_fake_response([]))
+      visit "/board/hoxton"
+
+      expect(page).to have_content("Hoxton Test01 Meeting Room")
+      expect(page).to have_content("Hoxton Test02 Meeting Room")
+      expect(page).to have_content("Hoxton Test03 Meeting Room")
+      expect(page).not_to have_content("Leeds Test01 Meeting Room")
+      expect(page).not_to have_content("Zoom Test01 Meeting Room")
+    end
+  end
+
+  context "get '/board/leeds" do
+    it "shows the current time" do
+      stub_gcal_request(gcal_fake_response([]))
+      visit "/board/leeds"
+
+      expect(page).to have_selector("#datetime_time", text: Time.now.strftime("%l:%M %P").strip)
+    end
+
+    it "shows the four meeting rooms" do
+      stub_gcal_request(gcal_fake_response([]))
+      visit "/board/leeds"
+
+      expect(page).to have_content("Leeds Test01 Meeting Room")
+      expect(page).to have_content("Leeds Test02 Meeting Room")
+      expect(page).to have_content("Leeds Test03 Meeting Room")
+      expect(page).to have_content("Leeds Test04 Meeting Room")
+      expect(page).not_to have_content("Hoxton Test01 Meeting Room")
+      expect(page).not_to have_content("Zoom Test01 Meeting Room")
+    end
+  end
+end

--- a/spec/app_check_spec.rb
+++ b/spec/app_check_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+RSpec.describe "App" do
+  context "GET '/check'" do
+    let(:response) { get "/check" }
+    it "shows a message" do
+      expect(response.body).to eq("I'm alive!")
+    end
+  end
+end

--- a/spec/app_room_view_spec.rb
+++ b/spec/app_room_view_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe "Room view", type: :feature do
+  before do
+    Capybara.app = Sinatra::Application
+    stub_const("CACHE_EXPIRY_TIMEOUT", 0) # Overriding this constant so the response won't stay cached between examples
+  end
+
+  context 'get "/room/:slug"' do
+    context "when there are no meetings for the day" do
+      it "shows the room is empty until the next day" do
+        stub_gcal_request(gcal_fake_response([]))
+
+        visit "/room/hoxton_test03"
+
+        expect(page).to have_selector(".event.empty")
+        expect(page).to have_selector(".datetime", text: "UntilTomorrow")
+      end
+    end
+
+    context "when the room is empty now but there are meetings scheduled later on the day" do
+      it "shows the room is empty at the current moment" do
+        stub_gcal_request(gcal_fake_response(gcal_fake_events_with_attendees))
+        visit "/room/hoxton_test03"
+
+        expect(page).to have_selector(".event.empty")
+      end
+
+      it "shows the following meetings and displays the meeting details" do
+        stub_gcal_request(gcal_fake_response(gcal_fake_events_with_attendees))
+        visit "/room/hoxton_test03"
+
+        expect(find("ul")).to have_selector("li", count: 3) # Three 'li' elements: The two meetings and the room being empty at the moment
+        expect(page).to have_selector(".title", text: "sales - pipeline")
+        expect(page).to have_selector(".title", text: "sales - forward planning")
+        expect(page).to have_selector(".datetime", text: "3:00 pm – 3:30 pm")
+        expect(page).to have_selector(".datetime", text: "3:30 pm – 4:00 pm")
+        expect(page).to have_selector(".organiser", text: "Sales Person", count: 2) # The organiser is the same for both meetings
+      end
+    end
+
+    context "when there is a meeting going on at the moment" do
+      it "shows the details of the ongoing meeting and the following ones" do
+        ongoing_meeting_start_time = Time.current.rfc3339
+        ongoing_meeting_end_time = (Time.current + 30.minutes).rfc3339
+        second_meeting_start_time = (Time.current + 60.minutes).rfc3339
+        second_meeting_end_time = (Time.current + 120.minutes).rfc3339
+        stub_gcal_request(gcal_fake_response(gcal_fake_events_with_ongoing_meeting(ongoing_meeting_start_time, ongoing_meeting_end_time, second_meeting_start_time, second_meeting_end_time)))
+        visit "/room/hoxton_test03"
+
+        expect(page).to have_selector(".event.now")
+        expect(page).to have_selector(".title", text: "sales - pipeline")
+        expect(page).to have_selector(".datetime", text: "(29 mins)")
+        expect(find("ul")).to have_selector("li", count: 2)
+        expect(page).to have_selector(".title", text: "sales - forward planning")
+      end
+    end
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -118,6 +118,66 @@ module Helpers
     }]
   end
 
+  def gcal_fake_events_with_ongoing_meeting(start_time, end_time, second_start_time, second_end_time)
+    [{
+      "kind" => "calendar#event",
+      "etag" => "sales etag",
+      "id" => "sales test id",
+      "summary" => "sales - pipeline",
+      "description" => "sales meeting",
+      "organizer" => {
+        "email" => "sales@example.com",
+        "displayName" => "Sales Person"
+      },
+      "start" => {
+        "dateTime" => start_time
+      },
+      "end" => {
+        "dateTime" => end_time
+      },
+      "attendees" => [
+        {
+          "email" => "attendee01@example.com",
+          "displayName" => "Attendee 01",
+          "responseStatus" => "accepted"
+        },
+        {
+          "email" => "attendee02@example.com",
+          "displayName" => "Attendee 02",
+          "responseStatus" => "accepted"
+        }
+      ]
+    }, {
+      "kind" => "calendar#event",
+      "etag" => "sales planning etag",
+      "id" => "sales planning test id",
+      "summary" => "sales - forward planning",
+      "description" => "sales planning meeting",
+      "organizer" => {
+        "email" => "sales@example.com",
+        "displayName" => "Sales Person"
+      },
+      "start" => {
+        "dateTime" => second_start_time
+      },
+      "end" => {
+        "dateTime" => second_end_time
+      },
+      "attendees" => [
+        {
+          "email" => "attendee01@example.com",
+          "displayName" => "Attendee 01",
+          "responseStatus" => "accepted"
+        },
+        {
+          "email" => "attendee02@example.com",
+          "displayName" => "Attendee 02",
+          "responseStatus" => "accepted"
+        }
+      ]
+    }]
+  end
+
   def stub_gcal_request(body)
     stub_request(:any, /www.googleapis.com/)
       .to_return(body: body, headers: {"Content-Type" => "application/json"})

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,125 @@
+module Helpers
+  def gcal_fake_response(items)
+    {
+      "kind" => "calendar#events",
+      "etag" => "test etag",
+      "summary" => "test summary",
+      "description" => "test description",
+      "items" => items
+    }.to_json
+  end
+
+  def gcal_fake_events_with_attendees
+    [{
+      "kind" => "calendar#event",
+      "etag" => "sales etag",
+      "id" => "sales test id",
+      "summary" => "sales - pipeline",
+      "description" => "sales meeting",
+      "organizer" => {
+        "email" => "sales@example.com",
+        "displayName" => "Sales Person"
+      },
+      "start" => {
+        "dateTime" => "2020-07-20T15:00:00+01:00"
+      },
+      "end" => {
+        "dateTime" => "2020-07-20T15:30:00+01:00"
+      },
+      "attendees" => [
+        {
+          "email" => "attendee01@example.com",
+          "displayName" => "Attendee 01",
+          "responseStatus" => "accepted"
+        },
+        {
+          "email" => "attendee02@example.com",
+          "displayName" => "Attendee 02",
+          "responseStatus" => "accepted"
+        }
+      ]
+    }, {
+      "kind" => "calendar#event",
+      "etag" => "sales planning etag",
+      "id" => "sales planning test id",
+      "summary" => "sales - forward planning",
+      "description" => "sales planning meeting",
+      "organizer" => {
+        "email" => "sales@example.com",
+        "displayName" => "Sales Person"
+      },
+      "start" => {
+        "dateTime" => "2020-07-20T15:30:00+01:00"
+      },
+      "end" => {
+        "dateTime" => "2020-07-20T16:00:00+01:00"
+      },
+      "attendees" => [
+        {
+          "email" => "attendee01@example.com",
+          "displayName" => "Attendee 01",
+          "responseStatus" => "accepted"
+        },
+        {
+          "email" => "attendee02@example.com",
+          "displayName" => "Attendee 02",
+          "responseStatus" => "accepted"
+        }
+      ]
+    }]
+  end
+
+  def gcal_fake_events_without_attendees
+    [{
+      "kind" => "calendar#event",
+      "etag" => "sales etag",
+      "id" => "sales test id",
+      "summary" => "sales - pipeline",
+      "description" => "sales meeting",
+      "organizer" => {
+        "email" => "sales@example.com",
+        "displayName" => "Sales Person"
+      },
+      "start" => {
+        "dateTime" => "2020-07-20T15:00:00+01:00"
+      },
+      "end" => {
+        "dateTime" => "2020-07-20T15:30:00+01:00"
+      },
+      "attendees" => []
+    }, {
+      "kind" => "calendar#event",
+      "etag" => "sales planning etag",
+      "id" => "sales planning test id",
+      "summary" => "sales - forward planning",
+      "description" => "sales planning meeting",
+      "organizer" => {
+        "email" => "sales@example.com",
+        "displayName" => "Sales Person"
+      },
+      "start" => {
+        "dateTime" => "2020-07-20T15:30:00+01:00"
+      },
+      "end" => {
+        "dateTime" => "2020-07-20T16:00:00+01:00"
+      },
+      "attendees" => [
+        {
+          "email" => "attendee01@example.com",
+          "displayName" => "Attendee 01",
+          "responseStatus" => "declined"
+        },
+        {
+          "email" => "attendee02@example.com",
+          "displayName" => "Attendee 02",
+          "responseStatus" => "declined"
+        }
+      ]
+    }]
+  end
+
+  def stub_gcal_request(body)
+    stub_request(:any, /www.googleapis.com/)
+      .to_return(body: body, headers: {"Content-Type" => "application/json"})
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+ENV["RACK_ENV"] = "test"
+require "rack/test"
+require "capybara/rspec"
+require "active_support/testing/time_helpers"
+require "active_support/time"
+require_relative "../app.rb"
+require_relative "./helpers.rb"
+require "webmock/rspec"
+WebMock.disable_net_connect!(allow_localhost: true)
+
+module RspecHelper
+  include Rack::Test::Methods
+  def app
+    Sinatra::Application
+  end
+end
+
+RSpec.configure do |config|
+  config.include RspecHelper
+  config.include Helpers
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.include Capybara::DSL
+  config.include Capybara::RSpecMatchers
+  config.before(:all, type: :feature) do
+    WebMock.allow_net_connect!
+  end
+end

--- a/spec/test.env
+++ b/spec/test.env
@@ -1,0 +1,3 @@
+RACK_ENV=test
+GOOGLE_CLIENT_ID=fakeclientid.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=

--- a/spec/test_boards.json
+++ b/spec/test_boards.json
@@ -1,0 +1,18 @@
+[
+  {
+    "slug": "dxw",
+    "name": "dxw",
+    "rooms": ["zoom_test01", "zoom_test02", "zoom_test03"]
+  },
+  {
+    "slug": "hoxton",
+    "name": "Hoxton Office",
+    "rooms": ["hoxton_test01", "hoxton_test02", "hoxton_test03"]
+  },
+  {
+    "slug": "leeds",
+    "name": "Leeds Office",
+    "rooms": ["leeds_test01", "leeds_test02", "leeds_test03", "leeds_test04"],
+    "show_clock": true
+  }
+]

--- a/spec/test_rooms.json
+++ b/spec/test_rooms.json
@@ -1,0 +1,66 @@
+[
+  {
+    "slug": "hoxton_test01",
+    "name": "Hoxton Test01 Meeting Room",
+    "css_class": "room__hoxton-ground",
+    "gcal_identifier": "dxw.com_2d36303034323634352d353334@resource.calendar.google.com"
+  },
+  {
+    "slug": "hoxton_test02",
+    "name": "Hoxton Test02 Meeting Room",
+    "css_class": "room__hoxton-hide",
+    "gcal_identifier": "dxw.com_3936393930353336393539@resource.calendar.google.com"
+  },
+  {
+    "slug": "hoxton_test03",
+    "name": "Hoxton Test03 Meeting Room",
+    "css_class": "room__hoxton-wellbeing",
+    "gcal_identifier": "dxw.com_3437393236383531353437@resource.calendar.google.com"
+  },
+  {
+    "slug": "leeds_test01",
+    "name": "Leeds Test01 Meeting Room",
+    "css_class": "room__leeds-mustard",
+    "gcal_identifier": "dxw.com_18862haevrjfegh8jgp0540eipjn86gb74s3ac9n6spj6c9l6g@resource.calendar.google.com",
+    "presence_colour_rgb": [168, 87, 17]
+  },
+  {
+    "slug": "leeds_test02",
+    "name": "Leeds Test02 Meeting Room",
+    "css_class": "room__leeds-peacock",
+    "gcal_identifier": "dxw.com_188326f7n3qtqiqjmqptmimskfsmu6g86cp38dhk68s34@resource.calendar.google.com",
+    "presence_colour_rgb": [50, 139, 168]
+  },
+  {
+    "slug": "leeds_test03",
+    "name": "Leeds Test03 Meeting Room",
+    "css_class": "room__leeds-plum",
+    "gcal_identifier": "dxw.com_188al9agrcprmgaki2tcu1r5i0eim6gb64o30dpj6opj4d9g6s@resource.calendar.google.com",
+    "presence_colour_rgb": [59, 11, 59]
+  },
+  {
+    "slug": "leeds_test04",
+    "name": "Leeds Test04 Meeting Room",
+    "css_class": "room__leeds-green",
+    "gcal_identifier": "dxw.com_1887p1bi29mkqi6sgnh07chkatufk6ga64o32chj70q32dhn@resource.calendar.google.com",
+    "presence_colour_rgb": [20, 87, 15]
+  },
+  {
+    "slug": "zoom_test01",
+    "name": "Zoom Test01 Meeting Room",
+    "css_class": "room__zoom-a",
+    "gcal_identifier": "dxw.com_188fvcktkaps6grlmf2sr2lhn6nnk@resource.calendar.google.com"
+  },
+  {
+    "slug": "zoom_test02",
+    "name": "Zoom Test02 Meeting Room",
+    "css_class": "room__zoom-b",
+    "gcal_identifier": "dxw.com_188ejcf5p6aluidmn9650faudo5eg@resource.calendar.google.com"
+  },
+  {
+    "slug": "zoom_test03",
+    "name": "Zoom Test03 Meeting Room",
+    "css_class": "room__zoom-c",
+    "gcal_identifier": "dxw.com_188drohphtvniidqkrud8jujqvvqu@resource.calendar.google.com"
+  }
+]

--- a/spec/test_token.yaml
+++ b/spec/test_token.yaml
@@ -1,0 +1,2 @@
+---
+default: '{"client_id":"fakeclientid.apps.googleusercontent.com","access_token":"fake-access-token","refresh_token":"fake-refresh-access-token","scope":["https://www.googleapis.com/auth/calendar.readonly"],"expiration_time_millis":1594897355000}'

--- a/views/multi_room.haml
+++ b/views/multi_room.haml
@@ -8,7 +8,7 @@
     %h1
       %span#datetime_date #{@today.strftime('%A, %B %e')}
       -if @show_clock
-        %span#datetime_time
+        %span#datetime_time #{Time.now.strftime("%l:%M %P")}
     .calendar{"style" => "grid-template-columns: repeat(#{@rooms.count}, 1fr)"}
       - @rooms.each do |room|
         .room{:class => room.css_class}
@@ -44,4 +44,4 @@
     findClass[i].style.height = tallest + "px";
   }
 
-  equalHeights('calentry')
+


### PR DESCRIPTION
Trello: https://trello.com/c/40ZDCRFY

The meeting room dashboard started as a tiny Sinatra app with very small functionality, and no tests. It now does a lot more, and with added complexity comes a higher risk of something breaking, but it still doesn't have automated tests.

This PR introduces a test suite that covers both the API side and the user-facing app (dashboard). For these tests we are mainly using RSpec, Rack-test, WebMock and Capybara. The tests will also run on the CI build every time someone pushes or does a PR to the master branch.

Doing the tests revealed some bugs on the code that I have fixed too.